### PR TITLE
Namespace tracker-surrogates to prevent typo squatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "tracker-surrogates",
-  "version": "1.0.0",
+  "name": "@duckduckgo/tracker-surrogates",
   "description": "Surrogates are small scripts that our apps and extensions serve in place of trackers that cause things to break when blocked.",
   "scripts": {
     "lint-js": "eslint .",


### PR DESCRIPTION
I've also removed the version number as we can just rely on git commit sha's in our repos until/if we wish to publish this to npm (when we would add automation to bump the version and release etc).

This package.json is only used by the extension and current consumers will still work if not namespaced (but we should fix).