### PR TITLE
Add the supportedSurrogates.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ DuckDuckGo clients using surrogates:
 
 - `scripts/` - testing and deployment scripts
 - `surrogates/` - surrogate files
-- `mapping.json` - file that contains url match rules for which surrogates should be served
+- `supportedSurrogates.json` - file that contains a list of the currently supported surrogate scripts, for use by apps and extensions.
+- `mapping.json` - file that contains url match rules for which surrogates should be served, only for use when generating the block list.
 
 Format of the `mapping.json` file:
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "lint-js": "eslint .",
     "test-eval": "node ./scripts/test-eval.js",
     "test-mapping": "node ./scripts/test-mapping.js",
-    "test": "npm run lint-js && npm run test-mapping && npm run test-eval",
+    "test-supported-surrogates": "node ./scripts/test-supported-surrogates.js",
+    "test": "npm run lint-js && npm run test-mapping && npm run test-supported-surrogates && npm run test-eval",
     "build": "node ./scripts/concat.js"
   },
   "repository": {

--- a/scripts/test-supported-surrogates.js
+++ b/scripts/test-supported-surrogates.js
@@ -1,0 +1,35 @@
+// Ensures supportedSurrogates.json is up to date.
+
+const fs = require('fs');
+const path = require('path');
+
+const surrogatesDir = path.join(__dirname, '..', 'surrogates');
+
+const actualSurrogates = new Set();
+let supportedSurrogates = require('../supportedSurrogates.json');
+supportedSurrogates = new Set(supportedSurrogates);
+let failed = false;
+
+for (const surrogate of fs.readdirSync(surrogatesDir)) {
+    if (!supportedSurrogates.has(surrogate)) {
+        console.error(
+            '🛑 Surrogate missing from supportedSurrogates.json:',
+            surrogate
+        );
+        failed = true;
+    }
+
+    actualSurrogates.add(surrogate);
+}
+
+for (const surrogate of supportedSurrogates) {
+    if (!actualSurrogates.has(surrogate)) {
+        console.error(
+            '🛑 Unknown surrogate found in supportedSurrogates.json:',
+            surrogate
+        );
+        failed = true;
+    }
+}
+
+if (failed) process.exit(1);

--- a/supportedSurrogates.json
+++ b/supportedSurrogates.json
@@ -1,0 +1,16 @@
+[
+    "ad_status.js",
+    "adsbygoogle.js",
+    "amzn_ads.js",
+    "analytics.js",
+    "api.js",
+    "beacon.js",
+    "chartbeat.js",
+    "fb-sdk.js",
+    "ga.js",
+    "gpt.js",
+    "gtm.js",
+    "inpage_linkid.js",
+    "outbrain.js",
+    "youtube-iframe-api.js"
+]


### PR DESCRIPTION
If the block list is more recent than the bundled tracker-surrogates, it's possible that requests will be redirected to a file that does not exist. To handle that, we need a list of currently supported surrogate scripts that can be checked before performing the redirection.

Notes:
 - Along with mapping.json, supportedSurrogates.json should be updated manually when scripts are added/removed from the repository.
 - It was decided not to use the existing mapping.json file for this purpose, since we want to maintain flexibility in the mapping.json file format by avoiding using it for any other purposes.