### PR TITLE
Update the Facebook entity name in the surrogate script

### DIFF
--- a/surrogates/fb-sdk.js
+++ b/surrogates/fb-sdk.js
@@ -1,5 +1,6 @@
 (() => {
     'use strict';
+    const facebookEntity = 'Facebook, Inc.';
     const originalFBURL = document.currentScript.src;
     let siteInit = function () {};
     let fbIsEnabled = false;
@@ -15,7 +16,7 @@
     };
 
     function messageAddon (detailObject) {
-        detailObject.entity = 'Facebook';
+        detailObject.entity = facebookEntity;
         const event = new CustomEvent('ddg-ctp', {
             detail: detailObject,
             bubbles: false,
@@ -97,17 +98,17 @@
     }
 
     window.addEventListener('ddg-ctp-load-sdk', event => {
-        if (event.detail.entity === 'Facebook') {
+        if (event.detail.entity === facebookEntity) {
             enableFacebookSDK();
         }
     });
     window.addEventListener('ddg-ctp-run-login', event => {
-        if (event.detail.entity === 'Facebook') {
+        if (event.detail.entity === facebookEntity) {
             runFacebookLogin();
         }
     });
     window.addEventListener('ddg-ctp-cancel-modal', event => {
-        if (event.detail.entity === 'Facebook') {
+        if (event.detail.entity === facebookEntity) {
             fbLogin.callback({ });
         }
     });


### PR DESCRIPTION
At some point, the entity name for Facebook changed from "Facebook" to
"Facebook, Inc." in the block list. We have been slowly adjusting that
in the privacy-configuration, content-scope-scripts and extension
code. We need to update the entity name in the surrogate script too.
