### PR TITLE
Also check known video elements outside of the DOM

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,8 @@
     "rules": {
         "indent": ["error", 4],
         "semi": ["error", "always"],
-        "node/no-callback-literal": "off"
+        "node/no-callback-literal": "off",
+        "generator-star-spacing": ["error", {"before": false, "after": true}],
+        "yield-star-spacing": ["error", {"before": false, "after": true}]
     }
 }

--- a/surrogates/youtube-iframe-api.js
+++ b/surrogates/youtube-iframe-api.js
@@ -31,8 +31,13 @@
     // Mappings between the "real" video elements and their placeholder
     // elements.
     const videoElementsByID = new Map();
-    const videoElementByPlaceholderElement = new WeakMap();
-    const placeholderElementByVideoElement = new WeakMap();
+    const videoElementByPlaceholderElement = new Map();
+    const placeholderElementByVideoElement = new Map();
+
+    function* allVideoElements () {
+        yield* videoElementByPlaceholderElement.values();
+        yield* videoElementsByID.values();
+    }
 
     /**
      * Mock of the `YT.Player` constructor.
@@ -45,7 +50,18 @@
         const { height, width, videoId, playerVars = { }, events } = config;
 
         if (!(target instanceof Element)) {
-            target = document.getElementById(target);
+            const orignalTarget = target;
+            target = document.getElementById(orignalTarget);
+
+            if (!target) {
+                for (const videoElement of allVideoElements()) {
+                    // eslint-disable-next-line eqeqeq
+                    if (videoElement.id == orignalTarget) {
+                        target = videoElement;
+                        break;
+                    }
+                }
+            }
         }
 
         // Normalise target to always be the video element instead of the


### PR DESCRIPTION
The YouTube Click to Load surrogate script needs to be able to connect
an element ID to an existing YouTube video element. That needs to
work, even when the original element is no longer in the DOM. Let's
check the existing video maps too therefore.
