### PR TITLE
Harden the YouTube Iframe API surrogate script further

### DIFF
--- a/surrogates/fb-sdk.js
+++ b/surrogates/fb-sdk.js
@@ -183,4 +183,6 @@
             });
         }
     }
+
+    window.dispatchEvent(new CustomEvent('ddg-ctp-surrogate-load'));
 })();


### PR DESCRIPTION
It turns out that some websites use the YouTube Iframe API in a way
that's not really documented. I'm not sure why that is, but we should
still handle them correctly:

1. If the video ID isn't specified, it shouldn't be appended to the
   URL. The URL is broken either way, but some websites seem to later
   set the correct video ID after the video's load event is fired.
2. If the target of the `new YT.Player()` is an iframe element, the
   element should be reused instead of replaced with an iframe
   element. Also, parameters set directly in the iframe's src
   URL (instead of passed in the config Object) should be used.
3. If the website loads the YouTube Iframe API script after page load
   has completed, we should at least try to initiate the feature, even
   if some of the element mapping code-paths can't work. Otherwise, no
   placeholders are shown.
4. If the website waits for the onReady event to fire for a video
   _before_ setting the video ID, we should try to  handle that too.