### PR TITLE
Fix iframe sizes for custom iframe.

### DIFF
--- a/surrogates/youtube-iframe-api.js
+++ b/surrogates/youtube-iframe-api.js
@@ -237,8 +237,8 @@
                 target.src = url.href;
             } else {
                 const videoIframe = document.createElement('iframe');
-                videoIframe.height = parseInt(height, 10) || defaultHeight;
-                videoIframe.width = parseInt(width, 10) || defaultWidth;
+                videoIframe.height = height?.toString() || defaultHeight;
+                videoIframe.width = width?.toString() || defaultWidth;
                 videoIframe.src = url.href;
 
                 if (target.id) {


### PR DESCRIPTION
Use the string from the video config when available to get the correct size units instead of parsing to an int.
This fixes an issue where parsing an int of size "100%" became a video of "100" pixels.

Example page: 
https://playlist-randomizer.com/PLotWwwqNW_RuxxCCKYA2UT4kwICn-JsSN

![ctl-bug-size](https://github.com/duckduckgo/tracker-surrogates/assets/14364481/23fa1d1d-89ac-4b63-835c-b2d907ba1761)

After fix:

![ctl-fix-size](https://github.com/duckduckgo/tracker-surrogates/assets/14364481/2ebcabef-3117-4aff-9ca7-2eaf14395f47)

I'm using `.toString()` the same way Google's `www-widgetapi.js` script does it, by using the config string provided by the page.

<img width="681" alt="image" src="https://github.com/duckduckgo/tracker-surrogates/assets/14364481/21c5a515-ecbe-41dd-9a0c-1cb5de344cc8">
