### PR TITLE
Expand adsbygoogle.js surrogate script

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,17 @@
-Copyright (c) 2021 Duck Duck Go, Inc.
+Copyright (c) 2021-2023 Duck Duck Go, Inc.
+
+This work as a whole is licensed under the Apache License, Version 2.0 (the "License"); you may not use this code except in compliance with the License. You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+The work incorporates open source code from third parties that was originally licensed as follows:
+
+Mozilla's source code at https://searchfox.org/mozilla-central/source/browser/extensions/webcompat/shims <br>
+Mozilla Public License, v. 2.0. http://mozilla.org/MPL/2.0/.
 
 ## Apache License
 ### Version 2.0, January 2004

--- a/surrogates/adsbygoogle.js
+++ b/surrogates/adsbygoogle.js
@@ -1,3 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Based on https://searchfox.org/mozilla-central/source/browser/extensions/webcompat/shims/google-ads.js
+
 (() => {
-    'use strict';
+    /**
+     * Bug 1713726 - Shim Ads by Google
+     *
+     * Sites relying on window.adsbygoogle may encounter breakage if it is blocked.
+     * This shim provides a stub for that API to mitigate that breakage.
+     */
+
+    if (window.adsbygoogle?.loaded === undefined) {
+        window.adsbygoogle = {
+            loaded: true,
+            push () {}
+        };
+    }
+
+    if (window.gapi?._pl === undefined) {
+        const stub = {
+            go () {},
+            render: () => ''
+        };
+        window.gapi = {
+            _pl: true,
+            additnow: stub,
+            autocomplete: stub,
+            backdrop: stub,
+            blogger: stub,
+            commentcount: stub,
+            comments: stub,
+            community: stub,
+            donation: stub,
+            family_creation: stub,
+            follow: stub,
+            hangout: stub,
+            health: stub,
+            interactivepost: stub,
+            load () {},
+            logutil: {
+                enableDebugLogging () {}
+            },
+            page: stub,
+            partnersbadge: stub,
+            person: stub,
+            platform: {
+                go () {}
+            },
+            playemm: stub,
+            playreview: stub,
+            plus: stub,
+            plusone: stub,
+            post: stub,
+            profile: stub,
+            ratingbadge: stub,
+            recobar: stub,
+            savetoandroidpay: stub,
+            savetodrive: stub,
+            savetowallet: stub,
+            share: stub,
+            sharetoclassroom: stub,
+            shortlists: stub,
+            signin: stub,
+            signin2: stub,
+            surveyoptin: stub,
+            visibility: stub,
+            youtube: stub,
+            ytsubscribe: stub,
+            zoomableimage: stub
+        };
+    }
+
+    const spoofAdElements = () => {
+        const insElements = document.querySelectorAll('ins.adsbygoogle');
+        for (let i = 0; i < insElements.length; i++) {
+            const iframeId = 'aswift_' + (i + 1);
+            const divId = iframeId + '_host';
+
+            if (document.getElementById(divId) ||
+                document.getElementById(iframeId)) {
+                continue;
+            }
+
+            const iframeElement = document.createElement('iframe');
+            iframeElement.style.setProperty('display', 'none', 'important');
+            iframeElement.style.setProperty('visibility', 'collapse', 'important');
+            iframeElement.id = iframeId;
+            iframeElement.setAttribute('name', iframeId);
+            iframeElement.setAttribute(
+                'data-google-container-id', 'a!' + (i + 2)
+            );
+            iframeElement.setAttribute(
+                'data-google-query-id', '00000000000000-00000000000'
+            );
+            iframeElement.setAttribute('data-load-complete', 'true');
+
+            const divElement = document.createElement('div');
+            divElement.style.setProperty('display', 'none', 'important');
+            divElement.style.setProperty('visibility', 'collapse', 'important');
+            divElement.id = divId;
+            divElement.setAttribute('title', 'advertisement');
+            divElement.setAttribute('aria-label', 'Advertisement');
+            divElement.appendChild(iframeElement);
+
+            const insElement = insElements[i];
+            insElement.style.setProperty('display', 'none', 'important');
+            insElement.style.setProperty('visibility', 'collapse', 'important');
+            insElement.setAttribute('data-ad-format', 'auto');
+            insElement.setAttribute('data-adsbygoogle-status', 'done');
+            insElement.setAttribute('data-ad-status', 'filled');
+            insElement.appendChild(divElement);
+        }
+    };
+
+    if (document.readyState !== 'loading') {
+        spoofAdElements();
+    } else {
+        window.addEventListener(
+            'DOMContentLoaded', spoofAdElements, { once: true }
+        );
+    }
 })();


### PR DESCRIPTION
(Depends on https://github.com/duckduckgo/tracker-surrogates/pull/18)

While redirecting requests for the adsbygoogle.js script to an
effectively empty script does often work, some websites break or
detect that the ads were not displayed.

Let's improve on that, by starting with Mozilla's surrogate script[1],
and adding some logic to setup the rough element structure that the
real script creates.

1 - https://searchfox.org/mozilla-central/source/browser/extensions/webcompat/shims/google-ads.js