### PR TITLE
Add warning about updating mapping.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Format of the `mapping.json` file:
 }
 ```
 
+⚠️**Warning**: Be careful when adding new surrogate scripts to the `mapping.json`
+              file. The block lists are regenerated using the version of
+              `mapping.json` pushed to main (not the version most recently
+              released). From there, redirection rules are automatically added,
+              sometimes even for requests that have specific exceptions. If the
+              surrogate script in question is not yet available on a given
+              platform, the corresponding requests might start being blocked!⚠️
+
 ## Contributing
 
 We don't take external contributions at this time, but please feel free to open issues.


### PR DESCRIPTION
It turns out that updating the mapping.json file is kind of
risky. While platforms take the surrogates scripts from the latest
release, mapping.json is taken straight from the HEAD of
main. Redirection rules are then automatically added, sometimes even
when the request would have otherwise been allowlisted. This is made
riskier since if a platform does not have a surrogate script for a
rule yet, the corresponding requests will be blocked instead of
redirected. I've added a warning to the README to hopefully help folks
avoid this trap.
