### PR TITLE
Improve the google-ima.js surrogate script

### DIFF
--- a/surrogates/google-ima.js
+++ b/surrogates/google-ima.js
@@ -222,6 +222,12 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
   const ima = {};
 
   class AdDisplayContainer {
+    constructor(containerElement) {
+      const divElement = document.createElement("div");
+      divElement.style.setProperty("display", "none", "important");
+      divElement.style.setProperty("visibility", "collapse", "important");
+      containerElement.appendChild(divElement);
+    }
     destroy() {}
     initialize() {}
   }
@@ -324,17 +330,30 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
       }
     }
 
-    addEventListener(t, c) {
-      if (!this.listeners.has(t)) {
-        this.listeners.set(t, new Set());
+    addEventListener(types, c) {
+      if (!Array.isArray(types)) {
+        types = [types];
       }
-      this.listeners.get(t).add(c);
+
+      for (const t of types) {
+        if (!this.listeners.has(t)) {
+          this.listeners.set(t, new Set());
+        }
+        this.listeners.get(t).add(c);
+      }
     }
 
-    removeEventListener(t, c) {
-      const typeSet = this.listeners.get(t);
-      if (!typeSet) { return; }
-      typeSet.delete(c);
+    removeEventListener(types, c) {
+      if (!Array.isArray(types)) {
+        types = [types];
+      }
+
+      for (const t of types) {
+        const typeSet = this.listeners.get(t);
+        if (typeSet) {
+          typeSet.delete(c);
+        }
+      }
     }
   }
 
@@ -542,7 +561,7 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
       return "unknown";
     }
     getUniversalAdIds() {
-      return [""];
+      return [new UniversalAdIdInfo()];
     }
     getUniversalAdIdValue() {
       return "unknown";
@@ -752,7 +771,7 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
     getAdIdRegistry() {
       return "";
     }
-    getAdIsValue() {
+    getAdIdValue() {
       return "";
     }
   }
@@ -779,6 +798,12 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
       DOMAIN: "domain",
       FULL: "full",
       LIMITED: "limited",
+    },
+    OmidVerificationVendor: {
+      1: "OTHER",
+      2: "GOOGLE",
+      GOOGLE: 2,
+      OTHER: 1
     },
     settings: new ImaSdkSettings(),
     UiElements: {


### PR DESCRIPTION
We made use of uBlock's version of Mozilla's mock google-ima.js
script. The hope was that it would already be quite hardened and
reliable. Unfortunately however, we found that the script broke some
websites. After debugging, we found some missing attributes/behaviour
that some sites needed:

- The AdDisplayContainer[2] constructor usually creates some DOM
  elements inside the given container. They are all nested within a
  DIV and some websites break when at least that top DIV element isn't
  created.
- While not documented (that I could see), the event listeners can be
  added using an array of event types. Some websites make use of that
  and then hang forever when the expected events aren't fired. This
  caused videos not to play on some websites.
- The Ad.prototype.getUniversalAdIds()[3] method should return an
  array of UniversalAdIdInfo Objects, instead of an Array of
  strings. When an array of strings are returned, some websites then
  break when the UniversalAdIdInfo's methods are missing.
- The UniversalAdIdInfo.prototype.getAdIdValue()[4] method had a typo
  in the name ("getAsIdValue") and was effectively missing. That
  caused some websites to break when the missing method was called.
- The google.ima.OmidVerificationVendor[5] Object was missing, which
  broke some websites that attempted to access it.

1 - https://github.com/gorhill/uBlock/blob/master/src/web_accessible_resources/google-ima.js
2 - https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/reference/js/google.ima.AdDisplayContainer
3 - https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/reference/js/google.ima.Ad#getUniversalAdIds
4 - https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/reference/js/google.ima.UniversalAdIdInfo#getAdIdValue
5 - https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/reference/js/google.ima#.OmidVerificationVendor