### PR TITLE
Further improve the google-ima.js surrogate script

### DIFF
--- a/surrogates/google-ima.js
+++ b/surrogates/google-ima.js
@@ -320,8 +320,9 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
     }
 
     _dispatch(e) {
-      const listeners = this.listeners.get(e.type) || [];
-      for (const listener of Array.from(listeners)) {
+      let listeners = this.listeners.get(e.type);
+      listeners = listeners ? Array.from(listeners.values()) : [];
+      for (const listener of listeners) {
         try {
           listener(e);
         } catch (r) {
@@ -330,16 +331,16 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
       }
     }
 
-    addEventListener(types, c) {
+    addEventListener(types, c, options, context) {
       if (!Array.isArray(types)) {
         types = [types];
       }
 
       for (const t of types) {
         if (!this.listeners.has(t)) {
-          this.listeners.set(t, new Set());
+          this.listeners.set(t, new Map());
         }
-        this.listeners.get(t).add(c);
+        this.listeners.get(t).set(c, c.bind(context || this));
       }
     }
 
@@ -623,7 +624,7 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
     getErrorCode() {
       return this.errorCode;
     }
-    getInnerError() {}
+    getInnerError() { return null; }
     getMessage() {
       return this.message;
     }


### PR DESCRIPTION
I worked through some of the websites listed in the uBlock issue[1]
for the google-ima.js surrogate script, to see what was going wrong:

1. It turns out the addEventListener method supports an optional
   context Object, which is bound to the listener if provided. Some
   websites make use of that, and then break when `this` is not
   bound correctly when events are dispatched.
2. The AdError.prototype.getInnerError()[2] method should return null
   or an Error Object, but was returning undefined. This broke
   websites that explicitly checked for null.

1 - https://github.com/uBlockOrigin/uBlock-issues/issues/2265
2 - https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/reference/js/google.ima.AdError#getInnerError