### PR TITLE
Ensure load event fires if preloading is enabled in google-ima.js

### DIFF
--- a/surrogates/google-ima.js
+++ b/surrogates/google-ima.js
@@ -397,6 +397,7 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
     constructor() {
       super();
       this.volume = 1;
+      this._enablePreloading = false;
     }
     collapse() {}
     configureAdsManager() {}
@@ -422,7 +423,11 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
     getVolume() {
       return this.volume;
     }
-    init(/* w, h, m, e */) {}
+    init(/* w, h, m, e */) {
+      if (this._enablePreloading) {
+        this._dispatch(new ima.AdEvent(AdEvent.Type.LOADED));
+      }
+    }
     isCustomClickTrackingUsed() {
       return false;
     }
@@ -726,7 +731,10 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
     constructor(type) {
       this.type = type;
     }
-    getAdsManager() {
+    getAdsManager(c, settings) {
+      if (settings && settings.enablePreloading) {
+        manager._enablePreloading = true;
+      }
       return manager;
     }
     getUserRequestContext() {


### PR DESCRIPTION
Some websites using the google-ima.js script choose to set the
enablePreloading[1] option. That should cause[2] the AdsManager.init()
method to cause the LOADED AdEvent to fire. If the event doesn't fire,
those websites can get stuck waiting forever. Most notably, this broke
a Trinity Audio voice narration widget that is used on some news
websites.

1 - https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/reference/js/google.ima.AdsRenderingSettings#enablePreloading
2 - https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/preload#timing