### PR TITLE
Ensure google-ima.js surrogate fires content pause/resume events correctly

### DIFF
--- a/surrogates/google-ima.js
+++ b/surrogates/google-ima.js
@@ -447,13 +447,14 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
         for (const type of [
           AdEvent.Type.LOADED,
           AdEvent.Type.STARTED,
-          AdEvent.Type.CONTENT_RESUME_REQUESTED,
+          AdEvent.Type.CONTENT_PAUSE_REQUESTED,
           AdEvent.Type.AD_BUFFERING,
           AdEvent.Type.FIRST_QUARTILE,
           AdEvent.Type.MIDPOINT,
           AdEvent.Type.THIRD_QUARTILE,
           AdEvent.Type.COMPLETE,
           AdEvent.Type.ALL_ADS_COMPLETED,
+          AdEvent.Type.CONTENT_RESUME_REQUESTED,
         ]) {
           try {
             this._dispatch(new ima.AdEvent(type));


### PR DESCRIPTION
The google-ima.js surrogate should fire the correct events when
AdManager.start() is called, to emulate the ads playing and
finishing. It's also important that these events[1] are fired in the
right order. CONTENT_PAUSE_REQUESTED should fire around when the ads
are starting, and CONTENT_RESUME_REQUESTED around when the ads have
finished. Correcting this ordering fixes website that use the Video.js
the integration of IMA, for example metro.co.uk.

1 - https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/reference/js/google.ima.AdEvent