### PR TITLE
Ensure Ad.data.length > 0 passes for google-ima.js surrogate

### DIFF
--- a/surrogates/google-ima.js
+++ b/surrogates/google-ima.js
@@ -447,13 +447,14 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
         for (const type of [
           AdEvent.Type.LOADED,
           AdEvent.Type.STARTED,
-          AdEvent.Type.CONTENT_RESUME_REQUESTED,
+          AdEvent.Type.CONTENT_PAUSE_REQUESTED,
           AdEvent.Type.AD_BUFFERING,
           AdEvent.Type.FIRST_QUARTILE,
           AdEvent.Type.MIDPOINT,
           AdEvent.Type.THIRD_QUARTILE,
           AdEvent.Type.COMPLETE,
           AdEvent.Type.ALL_ADS_COMPLETED,
+          AdEvent.Type.CONTENT_RESUME_REQUESTED,
         ]) {
           try {
             this._dispatch(new ima.AdEvent(type));

--- a/surrogates/google-ima.js
+++ b/surrogates/google-ima.js
@@ -397,6 +397,7 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
     constructor() {
       super();
       this.volume = 1;
+      this._enablePreloading = false;
     }
     collapse() {}
     configureAdsManager() {}
@@ -422,7 +423,11 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
     getVolume() {
       return this.volume;
     }
-    init(/* w, h, m, e */) {}
+    init(/* w, h, m, e */) {
+      if (this._enablePreloading) {
+        this._dispatch(new ima.AdEvent(AdEvent.Type.LOADED));
+      }
+    }
     isCustomClickTrackingUsed() {
       return false;
     }
@@ -726,7 +731,10 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
     constructor(type) {
       this.type = type;
     }
-    getAdsManager() {
+    getAdsManager(c, settings) {
+      if (settings && settings.enablePreloading) {
+        manager._enablePreloading = true;
+      }
       return manager;
     }
     getUserRequestContext() {

--- a/surrogates/google-ima.js
+++ b/surrogates/google-ima.js
@@ -500,6 +500,7 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
   class Ad {
     constructor() {
       this._pi = new AdPodInfo();
+      this.data = [1];
     }
     getAdId() {
       return "";


### PR DESCRIPTION
Some websites check the length of an undocumented property Ad.data,
before accepting a CONTENT_RESUME_REQUESTED AdEvent event. Let's stub
that data property out.