### PR TITLE
Add some more noop.js redirection rules

### DIFF
--- a/mapping.json
+++ b/mapping.json
@@ -22,7 +22,9 @@
     ],
     "googlesyndication.com": [
         { "regexRule": "googlesyndication\\.com\\/adsbygoogle\\.js", "surrogate": "adsbygoogle.js" },
-        { "regexRule": "googlesyndication\\.com\\/pagead\\/js\\/adsbygoogle\\.js", "surrogate": "adsbygoogle.js" }
+        { "regexRule": "googlesyndication\\.com\\/pagead\\/show_ads\\.js", "surrogate": "noop.js" },
+        { "regexRule": "googlesyndication\\.com\\/pagead\\/js\\/adsbygoogle\\.js", "surrogate": "adsbygoogle.js" },
+        { "regexRule": "googlesyndication\\.com\\/pagead\\/js\\/.*\\/osd_listener\\.js", "surrogate": "noop.js" }
     ],
     "doubleclick.net": [
         { "regexRule": "doubleclick\\.net\\/instream\\/ad_status\\.js", "surrogate": "ad_status.js" },
@@ -58,5 +60,8 @@
     "youtube-nocookie.com": [
         { "regexRule": "youtube-nocookie\\.com\\/iframe_api", "surrogate": "youtube-iframe-api.js", "action": "block-ctl-yt" },
         { "regexRule": "youtube-nocookie\\.com\\/player_api", "surrogate": "youtube-iframe-api.js", "action": "block-ctl-yt" }
+    ],
+    "gemius.pl": [
+        { "regexRule": "gemius\\.pl\\/gplayer\\.js", "surrogate": "noop.js" }
     ]
 }


### PR DESCRIPTION
After analysing uBlock[1] and Mozilla's[2] shim redirection rules, we
found some more noop.js redirections that fixed reproducible site
breakage. Let's add those rules now.

1 - https://github.com/gorhill/uBlock/blob/master/assets/assets.json
2 - https://hg.mozilla.org/mozilla-central/raw-file/tip/browser/extensions/webcompat/data/shims.js