### PR TITLE
Add Mozilla's Amazon apstag.js surrogate script

### DIFF
--- a/mapping.json
+++ b/mapping.json
@@ -22,7 +22,9 @@
     ],
     "googlesyndication.com": [
         { "regexRule": "googlesyndication\\.com\\/adsbygoogle\\.js", "surrogate": "adsbygoogle.js" },
-        { "regexRule": "googlesyndication\\.com\\/pagead\\/js\\/adsbygoogle\\.js", "surrogate": "adsbygoogle.js" }
+        { "regexRule": "googlesyndication\\.com\\/pagead\\/show_ads\\.js", "surrogate": "noop.js" },
+        { "regexRule": "googlesyndication\\.com\\/pagead\\/js\\/adsbygoogle\\.js", "surrogate": "adsbygoogle.js" },
+        { "regexRule": "googlesyndication\\.com\\/pagead\\/js\\/.*\\/osd_listener\\.js", "surrogate": "noop.js" }
     ],
     "doubleclick.net": [
         { "regexRule": "doubleclick\\.net\\/instream\\/ad_status\\.js", "surrogate": "ad_status.js" },

--- a/mapping.json
+++ b/mapping.json
@@ -37,6 +37,7 @@
         { "regexRule": "outbrain\\.com\\/outbrain\\.js", "surrogate": "outbrain.js" }
     ],
     "amazon-adsystem.com": [
+        { "regexRule": "amazon-adsystem\\.com\\/aax2\\/apstag\\.js", "surrogate": "amzn_apstag.js" },
         { "regexRule": "amazon-adsystem\\.com\\/aax2\\/amzn_ads\\.js", "surrogate": "amzn_ads.js" }
     ],
     "chartbeat.com": [

--- a/surrogates/amzn_apstag.js
+++ b/surrogates/amzn_apstag.js
@@ -1,0 +1,78 @@
+"use strict";
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Based on https://searchfox.org/mozilla-central/source/browser/extensions/webcompat/shims/apstag.js
+
+/* eslint indent: ["error", 2, {"SwitchCase": 1}], quotes: ["error", "double"],
+   comma-dangle: ["error", "only-multiline"], space-before-function-paren: ["error", "never"] */
+
+/**
+ * Bug 1713698 - Shim Amazon Transparent Ad Marketplace's apstag.js
+ *
+ * Some sites such as politico.com rely on Amazon TAM tracker to serve ads,
+ * breaking functionality like galleries if it is blocked. This shim helps
+ * mitigate major breakage in that case.
+ */
+
+if (!(window.apstag && window.apstag._getSlotIdToNameMapping)) {
+  const _Q = (window.apstag && window.apstag._Q) || [];
+
+  const newBid = config => {
+    return {
+      amznbid: "",
+      amzniid: "",
+      amznp: "",
+      amznsz: "0x0",
+      size: "0x0",
+      slotID: config.slotID,
+    };
+  };
+
+  window.apstag = {
+    _Q,
+    _getSlotIdToNameMapping() {},
+    bids() {},
+    debug() {},
+    deleteId() {},
+    fetchBids(cfg, cb) {
+      if (!Array.isArray(cfg && cfg.slots)) {
+        return;
+      }
+      setTimeout(() => {
+        cb(cfg.slots.map(s => newBid(s)));
+      }, 1);
+    },
+    init() {},
+    punt() {},
+    renderImp() {},
+    renewId() {},
+    setDisplayBids() {},
+    targetingKeys: () => [],
+    thirdPartyData: {},
+    updateId() {},
+  };
+
+  window.apstagLOADED = true;
+
+  _Q.push = function(prefix, args) {
+    try {
+      switch (prefix) {
+        case "f":
+          window.apstag.fetchBids(...args);
+          break;
+        case "i":
+          window.apstag.init(...args);
+          break;
+      }
+    } catch (e) {
+      console.trace(e);
+    }
+  };
+
+  for (const cmd of _Q) {
+    _Q.push(cmd);
+  }
+}


### PR DESCRIPTION
Some websites break when Amazon's apstag.js script is blocked. Let's
instead redirect such request to Mozilla's shim script[1].

1 - https://searchfox.org/mozilla-central/source/browser/extensions/webcompat/shims/apstag.js