### PR TITLE
Add missing AdRequest.omidAccessModeRules property in google-ima.js

### DIFF
--- a/surrogates/google-ima.js
+++ b/surrogates/google-ima.js
@@ -471,6 +471,9 @@ if (!window.google || !window.google.ima || !window.google.ima.VERSION) {
   class AdsRenderingSettings {}
 
   class AdsRequest {
+    constructor() {
+      this.omidAccessModeRules = {};
+    }
     setAdWillAutoPlay() {}
     setAdWillPlayMuted() {}
     setContinuousPlayback() {}


### PR DESCRIPTION
It turns out that an AdRequest class should have an
omidAccessModeRules[1] Object property. Some websites broke when
trying to access the missing property.

1 - https://developers.google.com/interactive-media-ads/docs/sdks/html5/client-side/reference/js/google.ima.AdsRequest#omidAccessModeRules