### PR TITLE
Harden _Q.push wrapper in the amzn_apstag.js shim

### DIFF
--- a/surrogates/amzn_apstag.js
+++ b/surrogates/amzn_apstag.js
@@ -57,7 +57,22 @@ if (!(window.apstag && window.apstag._getSlotIdToNameMapping)) {
 
   window.apstagLOADED = true;
 
+  const isIterable =
+    a => Array.isArray(a) ||
+         (typeof Symbol !== "undefined" && Symbol.iterator && a[Symbol.iterator]) ||
+         a.toString() === "[object Arguments]";
+
   _Q.push = function(prefix, args) {
+    // TODO: Check if this code path ever _isn't_ hit, seems like a bug in the
+    //       original shim implementation?
+    if (isIterable(prefix) && typeof args === "undefined") {
+      [prefix, ...args] = Array.from(prefix);
+    }
+
+    if (args && args.length === 1 && isIterable(args[0])) {
+      args = Array.from(args[0]);
+    }
+
     try {
       switch (prefix) {
         case "f":


### PR DESCRIPTION
Apstag calls are queued onto the `window.apstag._Q` array and are then
called when the Apstag script is ready. The shim expects each queued
call to be an array containing the API method name prefix and
arguments, e.g.

    ["f", {slots: [...], timeout: 3000}, () => { ... }]

I noticed in practice however, some calls are queued differently, with a
queued call looking something like this instead:

    [["f", Arguments([{slots: [...], timeout: 3000}, () => { ... }])]]

Since the original script handles that, the shim needs to as
well. Let's try our best here, without changing too much and risking
further breakage.